### PR TITLE
Adding a timeout option for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Example configuration for `cvmanager`:
       :user: admin
       :pass: changeme
       :uri: https://localhost
+      :timeout: 300
       :org: 1
       :lifecycle: 2
       :keep: 5
@@ -59,6 +60,7 @@ Example configuration for `cvmanager`:
 * `user`: username of a Satellite 6 user to execute the actions with
 * `pass`: password of the same user
 * `uri`: URI of the Satellite 6, `https://localhost` will work when executed directly on the Satellite machine
+* `timeout`: Timeout, in seconds, for any API calls made
 * `org`: Organization ID (not name) for managing content in
 * `livecycle`: target Lifecycle Environment ID (not name) for `promote`
 * `keep`: how many non-published versions of a Content View shall be kept when doing a `clean`

--- a/cvmanager
+++ b/cvmanager
@@ -5,13 +5,14 @@ require 'yaml'
 require 'apipie-bindings'
 
 @defaults = {
-  :noop      => false,
-  :keep      => 5,
-  :uri       => 'https://localhost/',
-  :user      => 'admin',
-  :pass      => 'changeme',
-  :org       => 1,
-  :lifecycle => 1,
+  :noop       => false,
+  :keep       => 5,
+  :uri        => 'https://localhost/',
+  :timeout    => 300,
+  :user       => 'admin',
+  :pass       => 'changeme',
+  :org        => 1,
+  :lifecycle  => 1,
 }
 
 @options = {
@@ -28,6 +29,9 @@ optparse = OptionParser.new do |opts|
 
   opts.on("-U", "--uri=URI", "URI to the Satellite") do |u|
     @options[:uri] = u
+  end
+  opts.on("-t", "--timeout=TIMEOUT", "Timeout value in seconds for any API calls. -1 means never timeout") do |t|
+    @options[:timeout] = t
   end
   opts.on("-u", "--user=USER", "User to log in to Satellite") do |u|
     @options[:user] = u
@@ -77,7 +81,7 @@ end
 @options[:keep] = @options[:keep].to_i
 
 def clean()
-  api = ApipieBindings::API.new({:uri => @options[:uri], :username => @options[:user], :password => @options[:pass], :api_version => '2'})
+  api = ApipieBindings::API.new({:uri => @options[:uri], :username => @options[:user], :password => @options[:pass], :api_version => '2', :timeout => @options[:timeout]})
 
   cvs = []
   req = api.resource(:content_views).call(:index, {:organization_id => @options[:org], :full_results => true})
@@ -111,7 +115,7 @@ def clean()
 end
 
 def update()
-  api = ApipieBindings::API.new({:uri => @options[:uri], :username => @options[:user], :password => @options[:pass], :api_version => '2'})
+  api = ApipieBindings::API.new({:uri => @options[:uri], :username => @options[:user], :password => @options[:pass], :api_version => '2', :timeout => @options[:timeout]})
 
   ccvs = []
   req = api.resource(:content_views).call(:index, {:organization_id => @options[:org], :full_results => true})
@@ -187,7 +191,7 @@ def update()
 end
 
 def promote()
-  api = ApipieBindings::API.new({:uri => @options[:uri], :username => @options[:user], :password => @options[:pass], :api_version => '2'})
+  api = ApipieBindings::API.new({:uri => @options[:uri], :username => @options[:user], :password => @options[:pass], :api_version => '2', :timeout => @options[:timeout]})
 
   ccvs = []
   req = api.resource(:content_views).call(:index, {:organization_id => @options[:org], :full_results => true})

--- a/cvmanager.yaml
+++ b/cvmanager.yaml
@@ -3,6 +3,7 @@
   :user: admin
   :pass: changeme
   :uri: https://localhost
+  :timeout: 300
   :org: 1
   :lifecycle: 2
   :keep: 5


### PR DESCRIPTION
Ran into issues where the apipie calls would timeout;  apipie allows for a timeout config value, so added an option for the script to consume and set timeouts for the api calls